### PR TITLE
Plan v0.2.1 — Workshop Clarity and Drift Control

### DIFF
--- a/docs/github-milestone-v0.2.1.md
+++ b/docs/github-milestone-v0.2.1.md
@@ -1,0 +1,89 @@
+# GitHub Milestone: v0.2.1
+
+## Title
+
+v0.2.1 — Workshop Clarity and Drift Control
+
+## Goal
+
+Make the Studio Workshop trustworthy as a daily working surface: stop label
+drift, stop bad memory, give the user a status header they can read at a
+glance, and finish the panel-vs-workshop responsibility split.
+
+## Why this milestone exists
+
+The v0.2.0 work landed the layered prompt blueprint, structured session
+memory, and the React Studio Workshop. The audit in 2026-05-03 (saved in
+session memory) confirmed the architecture is moving in the right direction
+but found that the UI exposes too many internal concepts at once and that
+memory entries are not clean enough to be trusted by the user or re-injected
+into prompts. v0.2.1 closes those gaps so v0.3 can build on a stable base.
+
+## Scope
+
+### Must Have (P0)
+
+- Stable `Agent A` / `Agent B` labels in any language (no Arabic drift to
+  "العميل").
+- Memory-quality validation that rejects placeholder fragments, markdown
+  headings, and short stubs before they enter `SessionMemory`.
+- `AgentSeat` persisted on every `TranscriptEntry` so the workshop timeline
+  never recomputes seat from index. (Already drafted as item 2 of
+  `06-studio-workshop-followups.md` — finish it.)
+- Status header in the Workshop that separates lifecycle status, round
+  progress, session phase, and current move into orthogonal fields.
+
+### Should Have (P1)
+
+- Side Panel becomes the launcher + history; Workshop becomes the operating
+  room. All live monitoring + intervention surfaces move to the Workshop.
+- Per-turn snapshot of the memory actually sent to the agent, persisted on
+  `TranscriptEntry`. UI reads from the snapshot, not a recomputation.
+- Prompt inspector inside the Workshop that lets the user view the rendered
+  blueprint that produced any given turn.
+
+### Not Yet (P2 / later)
+
+- Migrate `PING_PONG` from `ROLE_PROMPTS` to a sibling `PromptBlueprint`.
+- Per-session identity / operating-style overrides (the Agents tab today is
+  read-only by design).
+
+## Tracking Issues
+
+1. [#1](https://github.com/satabd/DualMind-Studio/issues/1) — P0: Stabilize Agent A/B labels in multilingual Agent Workshop
+2. [#2](https://github.com/satabd/DualMind-Studio/issues/2) — P0: Add memory quality validation before saving checkpoint memory
+3. [#3](https://github.com/satabd/DualMind-Studio/issues/3) — P0: Persist AgentSeat on TranscriptEntry and fix workshop speaker mapping
+4. [#4](https://github.com/satabd/DualMind-Studio/issues/4) — P0: Split lifecycle status from phase/intent in Workshop header
+5. [#5](https://github.com/satabd/DualMind-Studio/issues/5) — P1: Redesign Side Panel as launcher and Workshop as operating room
+6. [#6](https://github.com/satabd/DualMind-Studio/issues/6) — P1: Persist actually-sent prompt memory snapshot per turn
+7. [#7](https://github.com/satabd/DualMind-Studio/issues/7) — P1: Add prompt inspector for rendered blueprint
+8. [#8](https://github.com/satabd/DualMind-Studio/issues/8) — P2: Migrate PING_PONG from ROLE_PROMPTS to PromptBlueprint
+
+## Recommended execution order
+
+1. P0-1 Arabic Agent A/B drift
+2. P0-2 Memory quality validation
+3. P0-3 Persist AgentSeat on TranscriptEntry
+4. P0-4 Status header model
+5. P1-5 Panel/Workshop responsibility split
+6. P1-6 Per-turn memory snapshot
+7. P1-7 Prompt inspector
+8. P2-8 PING_PONG migration
+
+The P0 set is ordered before any UI redesign on purpose: a cleaner UI that
+still surfaces drifted labels and junk memory entries does not move the
+trust needle.
+
+## Exit Criteria
+
+- Discussion-mode runs in Arabic produce literal `Agent A` / `Agent B` in
+  every turn; repair detection catches drift if it happens.
+- No memory entry is shorter than the validator floor, and no entry equals
+  a known placeholder fragment. Existing test fixtures pass.
+- The Workshop timeline never shows the same model labelled both A and B in
+  one round, including after escalation+resume.
+- The Workshop header reads `Finished · 4/7 · Phase: Explore` after early
+  stop on round 4 of 7 with all entries in DIVERGE — never the conflated
+  `Idle · Round 4/7 · FINALIZE · critique`.
+- The Side Panel no longer renders the live timeline, memory previews, or
+  composer; the Workshop owns those surfaces.

--- a/docs/issues/07-stabilize-agent-ab-labels-multilingual.md
+++ b/docs/issues/07-stabilize-agent-ab-labels-multilingual.md
@@ -1,0 +1,87 @@
+# P0: Stabilize Agent A/B labels in multilingual Agent Workshop
+
+**GitHub:** [#1](https://github.com/satabd/DualMind-Studio/issues/1)
+**Milestone:** v0.2.1 — Workshop Clarity and Drift Control
+**Severity:** High
+**Mode affected:** DISCUSSION (Agent Workshop)
+
+## Problem
+
+When the discussion is conducted in Arabic, agents drift away from the
+literal seat labels and translate them, e.g.:
+
+```
+إلى العميل (أ)
+إلى العميل (ب)
+```
+
+instead of:
+
+```
+Agent A
+Agent B
+```
+
+This breaks identity stability across turns and makes the `getDiscussionViolation`
+repair pass less effective, because translated labels are not in its banned
+patterns list.
+
+## Root cause
+
+`src/promptBlueprint.ts` defines `DISCUSSION_PROTOCOL.rules` and the
+`[OUTPUT CONTRACT]` block, both of which say "Address the counterpart agent
+directly" / "Address Agent A directly" — but neither forbids translating
+those labels into the output language. When the latest input is Arabic the
+model produces Arabic output and naturally translates "Agent" to "العميل".
+
+## Proposed fix
+
+### 1. Add no-translate rules to the protocol
+
+In `src/promptBlueprint.ts`, append to `DISCUSSION_PROTOCOL.rules`:
+
+- `Use the exact labels "Agent A" and "Agent B" in any language. Do not translate these labels.`
+- `Your audience is the counterpart agent only. Never address the human.`
+- `Banned forms in any language (do not use): "العميل", "المستخدم", "صاحب السؤال", "حضرتك", "client", "user".`
+
+### 2. Reinforce in the output contract
+
+In `renderPromptBlueprint`, the `[OUTPUT CONTRACT]` block should also state:
+
+- `Keep the labels "Agent A" / "Agent B" literal even when replying in another language.`
+
+### 3. Detect drift in the repair pass
+
+In `src/background.ts` `getDiscussionViolation`, add:
+
+- `/العميل\s*\(?\s*[أا]\s*\)?/i` → "You translated the seat label. Keep `Agent A` literal."
+- `/العميل\s*\(?\s*[بب]\s*\)?/i` → "You translated the seat label. Keep `Agent B` literal."
+- `/(حضرتك|صاحب السؤال)/i` → "You addressed the human. Address the counterpart agent only."
+
+These trigger the existing repair → regenerate → forced-fallback ladder.
+
+## Acceptance criteria
+
+- A regression test renders the discussion blueprint and asserts that the
+  rendered prompt contains the no-translate clause.
+- A snapshot test of `getDiscussionViolation` returns a violation message
+  for inputs containing `إلى العميل (أ)` and `حضرتك`.
+- A manual test in Arabic produces output with literal `Agent A` / `Agent B`.
+
+## Files
+
+- `src/promptBlueprint.ts`
+- `src/background.ts`
+- `scripts/test-runtime-regressions-source.mjs` (or a new fixture)
+
+## Risk
+
+Low. Additive rule changes. Repair regex could over-trigger if "العميل"
+appears as part of the user's actual topic — keep the regex targeted to
+the parenthetical-letter shape so generic uses of the word are not caught.
+
+## Related
+
+- Audit finding F4 (2026-05-03 audit, saved in session context).
+- Connects loosely to issue 06 item 2 (persist seat on transcript) — clean
+  labels make the persisted seat reliable.

--- a/docs/issues/08-memory-quality-validation.md
+++ b/docs/issues/08-memory-quality-validation.md
@@ -1,0 +1,107 @@
+# P0: Add memory quality validation before saving checkpoint memory
+
+**GitHub:** [#2](https://github.com/satabd/DualMind-Studio/issues/2)
+**Milestone:** v0.2.1 — Workshop Clarity and Drift Control
+**Severity:** High
+
+## Problem
+
+Session memory is currently storing low-quality entries that look like raw
+artifacts rather than facts:
+
+```
+Risk: * risk_level
+Assumption: ## Gemini said
+Question: Unresolved Items:
+```
+
+Users see these in the Workshop Memory tab and in the side-panel
+"Session Memory" preview. Worse, they get re-injected into the next turn
+via `selectPromptMemory` → `[MEMORY]` block, which pollutes the prompt.
+
+## Root cause
+
+Two layers feed each other:
+
+1. `src/background.ts` `buildArtifacts` builds artifact buckets by
+   substring-matching transcript lines against words like `risk`, `?`,
+   `should`, `recommend`. It happily captures markdown headings, bullet
+   markers, and template fragments verbatim.
+2. `src/sessionMemory.ts` `memoryEntriesFromCheckpoint` then takes
+   `artifacts.decisions[0]`, `artifacts.risks[0]`, `artifacts.questions[0]`,
+   `artifacts.ideas[0] || artifacts.highlights[0]` — no validation, no
+   minimum length, no rejection of placeholders.
+
+The memory pipeline trusts whatever the artifact extractor produced.
+
+## Proposed fix
+
+### 1. Tighten `makeMemoryEntry` in `src/sessionMemory.ts`
+
+Reject entries whose normalized text:
+
+- is shorter than ~20 characters
+- matches `/^(#{1,6}\s|[-*]\s*$|\d+\.\s*$)/` (markdown heading, lone bullet, lone numbered marker)
+- equals or contains only a banned placeholder phrase. Suggested initial list:
+  - `Unresolved Items`
+  - `Established Facts`
+  - `Unsupported Claims`
+  - `Risks`
+  - `Questions`
+  - `Decisions`
+  - `* risk_level`
+  - `## Gemini said`
+  - `## ChatGPT said`
+- is wholly contained in a "label-only" pattern like `^[A-Z][a-z_]+:\s*$`
+
+If rejected, return `null` so `appendEntry` skips it.
+
+### 2. Tighten `buildArtifacts` in `src/background.ts`
+
+Before pushing a line into a bucket:
+
+- skip lines matching `/^#{1,6}\s/`
+- skip lines that are only a bullet/number marker
+- skip lines shorter than 20 characters of meaningful content
+- prefer the second non-trivial line of a turn over a heading-style first line
+
+### 3. Surface source on memory cards
+
+The audit recommended showing source explicitly on each entry (checkpoint
+turn N / moderator turn M / agent / system) so users can audit where each
+fact came from. The data is already in `entry.source` and `entry.tags`;
+just render it on the card.
+
+## Acceptance criteria
+
+- Unit test: `makeMemoryEntry("risk", "* risk_level", ...)` returns `null`.
+- Unit test: `makeMemoryEntry("question", "Unresolved Items:", ...)` returns `null`.
+- Unit test: `memoryEntriesFromCheckpoint` on a checkpoint whose artifact
+  buckets contain only placeholders returns `[]`.
+- Manual: existing live sessions stop accumulating obviously-junk entries.
+- The Workshop Memory tab shows source on each card.
+
+## Files
+
+- `src/sessionMemory.ts`
+- `src/background.ts` (`buildArtifacts`)
+- `src/studio/tabs/MemoryTab.tsx` (render source)
+- `scripts/test-runtime-regressions-source.mjs` (new memory validation tests)
+
+## Risk
+
+Medium. Overly strict filters could empty memory for short conclusions;
+keep the threshold conservative and add a unit test fixture of legitimate
+short conclusions that should pass.
+
+## Why before UI redesign
+
+The audit recommended doing this *before* the panel/workshop split.
+Otherwise the cleaner UI still displays bad memory and the user's trust
+problem doesn't move.
+
+## Related
+
+- Audit finding F7 (2026-05-03 audit).
+- Connects to issue 11 (per-turn memory snapshot): once snapshots are stored
+  per turn, having clean source memory matters even more.

--- a/docs/issues/09-persist-agent-seat-on-transcript-entry.md
+++ b/docs/issues/09-persist-agent-seat-on-transcript-entry.md
@@ -1,0 +1,88 @@
+# P0: Persist AgentSeat on TranscriptEntry and fix workshop speaker mapping
+
+**GitHub:** [#3](https://github.com/satabd/DualMind-Studio/issues/3)
+**Milestone:** v0.2.1 — Workshop Clarity and Drift Control
+**Severity:** High
+
+## Problem
+
+`TranscriptEntry` does not carry `AgentSeat`. Both the side-panel timeline
+and the Studio Workshop timeline recompute seat from `agentTurnIndex`,
+assuming strict alternation:
+
+- Round 1: first speaker = Agent A, second speaker = Agent B
+- Round 2: first speaker (now the other model) = Agent A, etc.
+
+That assumption breaks after escalation+resume. In `runBrainstormLoop`,
+when the first turn of a round emits `[ESCALATION_REQUIRED]`, the loop
+decrements `currentRound` and `continue`s — but the first turn has already
+been persisted. On resume, the same first speaker speaks again, producing
+two same-agent transcript entries inside what the orchestrator considers
+a single round. The recomputing UI then labels the second one as Agent B.
+
+Result: the same model appears as both Agent A and Agent B in one round.
+
+## Existing draft
+
+`docs/issues/06-studio-workshop-followups.md` item 2 ("Persist Reasoning
+Seat Per Turn") already drafted the persistence work. Use it as the
+starting point. This issue extends it with the escalation/resume edge
+case.
+
+## Proposed fix
+
+### 1. Persist seat on every turn
+
+Per issue 06 item 2:
+
+- Add `seat?: AgentSeat` to `TranscriptEntry` in `src/types.ts`.
+- Stamp `seat` when `background.ts` `persistTurn` writes a Gemini/ChatGPT turn.
+- For forced-fallback System turns, stamp the seat of the agent whose output failed repair.
+- Update the workshop timeline (`src/studio/components/Timeline.tsx`) and the panel timeline to read `entry.seat ?? deriveLegacySeat(entry, ...)`.
+
+### 2. Fix the escalation/resume reentry
+
+The cleanest fix is to *not* let the same speaker take two transcript
+slots in one round. Two viable approaches:
+
+- **A (preferred):** when `firstTurn.escalated`, do not decrement
+  `currentRound`. On resume, jump straight to the second-speaker turn for
+  the same round, with `resumeContext` folded into its prompt. The first
+  turn keeps its seat A; the second keeps its seat B.
+- **B (fallback):** keep the decrement, but on the next iteration force the
+  seat of the re-running first speaker to whatever it was before, *and*
+  skip persisting a duplicate transcript entry for it.
+
+Approach A removes the duplicate entirely.
+
+## Acceptance criteria
+
+- `TranscriptEntry.seat` is populated for every new turn.
+- Workshop and panel timelines read `entry.seat` first; recompute is
+  fallback only.
+- Regression: trigger an escalation on the first turn of round 2, resume
+  with feedback, and verify the timeline does not show the same model
+  labelled both A and B in round 2.
+- Old sessions saved before this change still render seats correctly via
+  the legacy recompute fallback.
+
+## Files
+
+- `src/types.ts`
+- `src/background.ts` (`executeAgentTurn`, `persistTurn`, `runBrainstormLoop`)
+- `src/studio/components/Timeline.tsx`
+- `src/panel.ts` (legacy timeline rendering, if still present after the
+  panel/workshop split lands)
+- `scripts/test-runtime-regressions-source.mjs`
+
+## Risk
+
+Medium. Persisted shape changes; old sessions need the recompute
+fallback. The escalation/resume change must not break the existing
+"escalation block in transcript" UX.
+
+## Related
+
+- Audit finding F5 (2026-05-03 audit).
+- Issue `06-studio-workshop-followups.md` item 2 — supersede or close once
+  this lands.

--- a/docs/issues/10-split-lifecycle-from-phase-intent-header.md
+++ b/docs/issues/10-split-lifecycle-from-phase-intent-header.md
@@ -1,0 +1,98 @@
+# P0: Split lifecycle status from phase/intent in Workshop header
+
+**GitHub:** [#4](https://github.com/satabd/DualMind-Studio/issues/4)
+**Milestone:** v0.2.1 — Workshop Clarity and Drift Control
+**Severity:** Medium
+
+## Problem
+
+The Studio Workshop header in `src/studio/components/Header.tsx` glues four
+orthogonal axes of state into one breadcrumb:
+
+```
+Idle · Round 4/7 · FINALIZE · critique
+```
+
+After the convergence-driven early stop in `runBrainstormLoop`, the engine
+state freezes with `currentPhase = "FINALIZE"` and a stale `currentIntent`,
+while the actual transcript shows mostly `DIVERGE` entries. The result is
+that the header contradicts the timeline.
+
+The four axes mean different things:
+
+- `active`/`isPaused`/`awaitingHumanDecision` → lifecycle status
+- `currentRound`/`rounds` → progress
+- `currentPhase` → which phase the engine *would* use for the next turn
+- `currentIntent` → which move the engine *would* make next
+
+After the loop ends, `currentPhase` and `currentIntent` are not meaningful
+and should not be shown.
+
+## Proposed fix
+
+### Status model
+
+```
+Lifecycle status: Idle | Running | Paused | Finished
+Round progress:   N of M (only when active or finished)
+Session phase:    Explore | Narrow | Finalize (derived from last completed turn's phase)
+Next move:        Expand | Critique | Verify | Combine | Narrow | Conclude (only while Running)
+```
+
+### Header implementation
+
+In `Header.tsx`, replace the single breadcrumb with three or four small
+fields:
+
+```
+Status: Running       (badge variant runs/pauses)
+Round:  3 of 7
+Phase:  Narrow
+Move:   Verify
+```
+
+When `Idle` or `Finished`, omit "Move". When deriving "Phase" for a
+finished session, take it from the last completed transcript entry's
+`phase`, not from `state.currentPhase`.
+
+### Friendly labels
+
+Use the friendly names, not the enum strings:
+
+- `DIVERGE → Explore`
+- `CONVERGE → Narrow`
+- `FINALIZE → Finalize`
+- `expand → Expand`, `critique → Critique`, `verify → Verify`,
+  `combine → Combine`, `narrow → Narrow`, `conclude → Conclude`,
+  `escalate → Escalation`, `synthesize → Synthesize`,
+  `moderate → Moderator`
+
+## Acceptance criteria
+
+- After early stop on round 4 of 7 with all entries `DIVERGE`, the header
+  reads `Finished · 4 of 7 · Phase: Explore` (no "Move", no "FINALIZE",
+  no "critique").
+- While running, the header reads `Running · Round 3 of 7 · Phase: Narrow · Move: Verify`.
+- When idle (no run started), only `Idle · No active session` shows.
+- The breadcrumb DOM ID `studioBreadcrumb` is preserved (the
+  `test-studio-workshop-source.mjs` test depends on it).
+
+## Files
+
+- `src/studio/components/Header.tsx`
+- `src/studio/store/workshop.ts` (optional helper: derive `lastTurnPhase`
+  from the selected session)
+- `src/i18n.ts` (add friendly-name translations if missing for both en/ar)
+
+## Risk
+
+Low. Pure presentation change once the derivation helper is added. The
+underlying `BrainstormState` shape does not need to change — but optionally
+adding `BrainstormState.lifecycleStatus: 'idle' | 'running' | 'paused' | 'finished'`
+would make the derivation cleaner and reusable from the panel.
+
+## Related
+
+- Audit finding F6 (2026-05-03 audit).
+- Audit's recommended copy table (section 9) covers the friendly-label
+  rename across the rest of the UI.

--- a/docs/issues/11-redesign-panel-launcher-workshop-operating-room.md
+++ b/docs/issues/11-redesign-panel-launcher-workshop-operating-room.md
@@ -1,0 +1,114 @@
+# P1: Redesign Side Panel as launcher and Workshop as operating room
+
+**GitHub:** [#5](https://github.com/satabd/DualMind-Studio/issues/5)
+**Milestone:** v0.2.1 — Workshop Clarity and Drift Control
+**Severity:** High (UX) / Medium (eng)
+
+## Problem
+
+The Side Panel and the Studio Workshop currently overlap heavily:
+
+| Surface | Pause/Resume/Stop | Live timeline | Memory | Prompt-used memory | Checkpoints | Composer | Escalation card | Setup | Profiles | Outputs/Finales | Branches | History |
+|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
+| Side Panel | yes | yes | yes | yes | yes | yes (via Moderator Override) | yes | yes | yes | yes | yes | yes |
+| Workshop | yes | yes | yes | no  | indirectly | yes (Composer) | yes | no  | no  | no  | no  | no  |
+
+The user cannot tell which surface owns what. First-time users get hit
+with ~25 affordances on the panel's Active Run tab alone.
+
+## Target product model
+
+```
+Side Panel:
+  Define Session → Start Run → Quick Monitor → Generate Outputs → History
+
+Workshop Window:
+  Observe → Understand → Steer → Resume → Narrow/Finalize → Inspect Memory/Decisions
+```
+
+## Proposed fix
+
+### Keep in the Side Panel (Basic)
+
+- Session Type
+- Speaking Order (First Agent + Flip; remove the disabled second-agent select)
+- Tab selectors for Gemini and ChatGPT (with green-dot when both detected)
+- Working Style chips (rename of "Creative Direction Presets")
+- Topic
+- Rounds
+- Start / Stop / Pause (small inline)
+- Open Workshop CTA
+- Compact live status (status badge + last 1–2 turns)
+- Generate Output (rename of "Finales")
+- History list
+
+### Side Panel "More options" (Advanced, collapsible)
+
+- Custom system prompts
+- Saved Profiles
+- Goal Framing (objective/constraints/success criteria)
+- Full Collaboration Style dropdown
+- Continue Session (additional rounds)
+
+### Move to the Workshop
+
+- Live timeline (full)
+- Memory tab
+- Prompt-used memory snapshot view (see issue 12)
+- Checkpoint cards
+- Branch picker
+- Moderator Composer
+- Escalation card
+- Detailed phase/intent/repair status
+
+### Auto-open Workshop on Start Run
+
+When the user clicks Start Run, open the Workshop window automatically so
+the live monitoring surface is in front. Keep a visible "Open Workshop"
+button in the panel for users who closed it.
+
+### Copy changes
+
+Apply the friendly-label table from the 2026-05-03 audit (section 9): rename
+"Creative Direction Presets" → "Working Style"; "Prompt-Used Memory" →
+"Memory sent to agents this turn"; "Repair: forced" → "Forced fallback";
+"Intervention Dock" → "Steering"; etc.
+
+## Acceptance criteria
+
+- Side Panel `panel.html` structural markup shrinks below ~150 lines.
+- The Workshop is the only surface with Composer, EscalationCard, full
+  Timeline, MemoryTab, and CheckpointCards.
+- A first-time user can complete the loop *Define Session → Start Run →
+  Monitor in Workshop → Generate Output → Review History* without seeing
+  duplicated controls between panel and workshop.
+- The friendly-label rename is applied across both surfaces.
+
+## Files
+
+- `src/panel.html`, `src/panel.ts`, `src/panel.css`
+- `src/studio/App.tsx` (no structural change, but absorb sections moved
+  from the panel as needed)
+- `src/i18n.ts` (rename keys + ar/en strings)
+
+## Risk
+
+Medium. Power users will lose one-click pause from the panel — keep a
+small Pause/Resume button in the panel header so the muscle-memory action
+still works. Profiles/branches getting hidden behind "More options" needs
+a clear collapsible affordance, otherwise users assume they are gone.
+
+## Why after P0
+
+This redesign is gated on:
+
+- Issue 8 (memory quality) — otherwise the Workshop's Memory tab still
+  shows junk entries after redesign.
+- Issue 10 (header status model) — otherwise the Workshop's header still
+  contradicts the timeline.
+
+## Related
+
+- Audit findings F1 and F2 (2026-05-03 audit).
+- Audit section 7 (Recommended UX Model) and section 9 (Proposed Copy
+  Changes).

--- a/docs/issues/12-persist-prompt-memory-snapshot-per-turn.md
+++ b/docs/issues/12-persist-prompt-memory-snapshot-per-turn.md
@@ -1,0 +1,88 @@
+# P1: Persist actually-sent prompt memory snapshot per turn
+
+**GitHub:** [#6](https://github.com/satabd/DualMind-Studio/issues/6)
+**Milestone:** v0.2.1 — Workshop Clarity and Drift Control
+**Severity:** Medium
+
+## Problem
+
+The "Prompt-Used Memory" preview in the side panel is computed by calling
+`selectPromptMemory(session.memory)` from `panel.ts` against the saved
+session. The orchestrator independently calls `selectPromptMemory` from
+`background.ts` `runBrainstormLoop` (line ~967) when actually building the
+prompt for the next turn.
+
+Two independent calls to the same function on the same data *should* match
+— but they can drift if:
+
+- the session memory changes between the two calls (moderator decision,
+  new checkpoint),
+- the parameters or priority weights diverge later,
+- a future selector becomes context-aware (e.g. "select memory relevant to
+  the current intent").
+
+The user is shown a "Prompt-Used Memory" panel that is not authoritative.
+
+## Proposed fix
+
+### 1. Snapshot at write time
+
+When `executeAgentTurn` builds a turn, the result of
+`selectPromptMemory(session.memory)` for that turn is already known.
+Persist it on the entry.
+
+In `src/types.ts`:
+
+```ts
+export interface TranscriptEntry {
+    // ... existing fields
+    promptMemorySnapshot?: MemoryEntry[];
+}
+```
+
+In `src/background.ts` `executeAgentTurn` / `persistTurn`, set
+`promptMemorySnapshot` to the `memory.entries` array that was actually
+included in the rendered blueprint for this turn.
+
+### 2. Read from the snapshot
+
+Update the side panel and the Workshop to read the latest entry's
+`promptMemorySnapshot` instead of recomputing. If the most recent agent
+turn has no snapshot (legacy data), fall back to the current recomputation
+so old sessions still render.
+
+### 3. Optional: persist the rendered prompt too
+
+Out of scope for this issue but a natural follow-up: `promptSnapshot?: string`
+on the entry, captured from `renderPromptBlueprint(...)`. Issue 13 (prompt
+inspector) depends on having this.
+
+## Acceptance criteria
+
+- Every new agent turn carries a `promptMemorySnapshot` reflecting exactly
+  what was sent.
+- The side panel's "Memory sent to agents this turn" view reads from the
+  latest entry's snapshot.
+- The Workshop optionally surfaces "memory sent for this turn" on each
+  timeline card (hover or expandable).
+- Storage cost stays small: cap at 8 entries (matches `selectPromptMemory`
+  default limit).
+
+## Files
+
+- `src/types.ts`
+- `src/background.ts` (`executeAgentTurn`, `persistTurn`)
+- `src/panel.ts` (replace recomputation with snapshot read)
+- `src/studio/components/Timeline.tsx` (optional per-turn snapshot view)
+
+## Risk
+
+Low. Storage delta is small (~8 entries × few hundred bytes per turn).
+
+## Related
+
+- Audit finding 6.E (2026-05-03 audit).
+- Issue 8 (memory quality validation) is upstream; cleaner memory makes
+  the snapshot more useful.
+- Issue 13 (prompt inspector) builds on this — once memory snapshot is
+  persisted, the next step is persisting the rendered prompt.

--- a/docs/issues/13-prompt-inspector-rendered-blueprint.md
+++ b/docs/issues/13-prompt-inspector-rendered-blueprint.md
@@ -1,0 +1,90 @@
+# P1: Add prompt inspector for rendered blueprint
+
+**GitHub:** [#7](https://github.com/satabd/DualMind-Studio/issues/7)
+**Milestone:** v0.2.1 — Workshop Clarity and Drift Control
+**Severity:** Medium
+
+## Problem
+
+The layered prompt blueprint exists (`renderPromptBlueprint` in
+`src/promptBlueprint.ts`) and is used for DISCUSSION mode, but the
+rendered prompt is not inspectable from the UI. There is no way for the
+user to:
+
+- see exactly what was sent for a given turn,
+- verify that memory entries were included,
+- verify that the protocol/output-contract rules were applied,
+- debug why an agent drifted.
+
+This makes the layered architecture invisible to its users.
+
+## Proposed fix
+
+### 1. Persist the rendered prompt per turn
+
+Add to `TranscriptEntry`:
+
+```ts
+promptSnapshot?: string;
+```
+
+Set it in `src/background.ts` `executeAgentTurn` when the prompt is built,
+before sending it to the tab. Skip persistence for repair/regenerate
+prompts (those are not the canonical turn prompt).
+
+### 2. Workshop inspector affordance
+
+In `src/studio/components/Timeline.tsx`, add a small "Show prompt" button
+to each turn card. Clicking it opens a modal or expandable panel that
+displays the `promptSnapshot` in a `<pre>` block with the six labelled
+sections:
+
+```
+[SYSTEM PROTOCOL] …
+[IDENTITY] …
+[ROLE DIRECTIVE] …
+[OPERATING STYLE] …
+[MEMORY] …
+[SESSION ANCHOR] …
+[SESSION CONTEXT] …
+[TURN TASK] …
+[OUTPUT CONTRACT] …
+```
+
+(`renderPromptBlueprint` already produces this structure.)
+
+### 3. Treat as Debug
+
+Hide the affordance behind a "Show debug info" toggle or place the
+inspector behind the same gate the audit recommends for raw repair status,
+raw intent/phase, etc. Most users do not need it; power users do.
+
+## Acceptance criteria
+
+- New turns persist `promptSnapshot`.
+- The Workshop has a per-turn "Show prompt" affordance, gated behind a
+  Debug toggle.
+- Clicking it shows the canonical layered prompt structure for that turn.
+- Storage cost is bounded — consider truncation or compression for very
+  long memory dumps.
+
+## Files
+
+- `src/types.ts`
+- `src/background.ts` (`executeAgentTurn`)
+- `src/studio/components/Timeline.tsx`
+- a new `src/studio/components/PromptInspector.tsx` (modal/expander)
+- `src/i18n.ts`
+
+## Risk
+
+Low–Medium. Storage cost is the main concern; rendered prompts can be
+several KB each. Mitigation: truncate to ~16KB or store only the layer
+labels + memory-entry IDs and re-render on demand from the entry's
+`promptMemorySnapshot` (issue 12) plus the session's framing.
+
+## Related
+
+- Audit finding F1 part of "no prompt inspection from the UI" gap
+  (2026-05-03 audit).
+- Issue 12 (memory snapshot) is upstream.

--- a/docs/issues/14-migrate-pingpong-to-prompt-blueprint.md
+++ b/docs/issues/14-migrate-pingpong-to-prompt-blueprint.md
@@ -1,0 +1,96 @@
+# P2: Migrate PING_PONG from ROLE_PROMPTS to PromptBlueprint
+
+**GitHub:** [#8](https://github.com/satabd/DualMind-Studio/issues/8)
+**Milestone:** v0.2.1 — Workshop Clarity and Drift Control
+**Severity:** Medium (architecture) / Low (user-visible)
+
+## Problem
+
+`PING_PONG` mode (Collaborative Exchange) still flows through the legacy
+`ROLE_PROMPTS` table in `src/background.ts` (lines ~172–238). The comment
+on line 171 acknowledges this: *"Legacy PING_PONG prompt path. DISCUSSION
+prompts use promptBlueprint.ts; migrate this table after the drift-control
+changes settle."*
+
+Consequences:
+
+- PING_PONG prompts have no `[SYSTEM PROTOCOL]`, no `[IDENTITY]`, no
+  `[OPERATING STYLE]`, no `[MEMORY]`, no `[OUTPUT CONTRACT]`.
+- Memory built up during a PING_PONG session is never read back into
+  prompts.
+- PING_PONG and DISCUSSION effectively behave like two different products.
+- Future improvements to the protocol or output contract have to be
+  duplicated in two places (or skipped for PING_PONG).
+
+## Proposed fix
+
+### 1. Add `buildPingPongBlueprint`
+
+In `src/promptBlueprint.ts`, mirror `buildDiscussionBlueprint` with a
+`buildPingPongBlueprint` that shares:
+
+- `protocol` (PING_PONG-specific protocol allowing user-facing framing,
+  since these turns are deliberately presentational)
+- `identity` (Agent A / Agent B identities can stay; or define
+  PING_PONG-specific ones if the role calls for it)
+- `style` (DEFAULT_STYLE)
+- `memory` (same `selectPromptMemory` flow)
+
+Differs in:
+
+- `task.instructions` — drawn from a small per-role task table that
+  replaces the per-agent init/loop functions in `ROLE_PROMPTS`.
+
+### 2. Wire it up
+
+In `src/background.ts` `executeAgentTurn`, replace the
+`isOpeningTurn ? agent.initPrompt(...) : agent.loopPrompt(...)` branch with
+`renderPromptBlueprint(buildPingPongBlueprint(...))`.
+
+Drop `addPhaseGuidance` once the blueprint includes phase guidance in its
+session-context layer.
+
+### 3. Delete `ROLE_PROMPTS` and `getAgentConfig` legacy bits
+
+After verifying parity on a fixture set of topics + roles, remove the
+legacy table.
+
+### 4. Migrate any custom-prompt support
+
+PING_PONG currently passes `customGeminiPrompt` / `customChatGPTPrompt`
+straight into the role functions for the `CUSTOM` role. The blueprint
+should accept these as part of `roleDirective` for the `CUSTOM` case so
+the user's custom prompt becomes one layer rather than the whole prompt.
+
+## Acceptance criteria
+
+- PING_PONG turn prompts contain the canonical six layers when rendered.
+- Session memory is read into PING_PONG prompts via `[MEMORY]`.
+- A regression fixture (one topic × each existing role) produces output
+  that is no worse than the legacy path on a small manual eval.
+- `ROLE_PROMPTS` and the legacy code path are removed.
+
+## Files
+
+- `src/promptBlueprint.ts`
+- `src/background.ts`
+- `scripts/test-runtime-regressions-source.mjs`
+
+## Risk
+
+Medium. PING_PONG roles like `EXPANDER` ("Yes, And…") and
+`HISTORIAN_FUTURIST` rely on very specific framings in the legacy prompts.
+The blueprint will need to preserve those framings inside the role
+directive layer to avoid regressing output quality.
+
+## Why P2
+
+Doing this before the P0 set risks destabilizing the one product surface
+that mostly works (PING_PONG). The audit recommended polishing prompt
+architecture *after* memory quality and UI clarity land.
+
+## Related
+
+- Audit finding F8 (2026-05-03 audit).
+- Issue 12 (per-turn memory snapshot) and issue 13 (prompt inspector)
+  become more useful once PING_PONG is on the blueprint.


### PR DESCRIPTION
Adds `docs/github-milestone-v0.2.1.md` and 8 tracking issue drafts in `docs/issues/`, linked to the GitHub issues already created in this repo.

## Tracking issues
- #1 P0: Stabilize Agent A/B labels in multilingual Agent Workshop
- #2 P0: Add memory quality validation before saving checkpoint memory
- #3 P0: Persist AgentSeat on TranscriptEntry and fix workshop speaker mapping
- #4 P0: Split lifecycle status from phase/intent in Workshop header
- #5 P1: Redesign Side Panel as launcher and Workshop as operating room
- #6 P1: Persist actually-sent prompt memory snapshot per turn
- #7 P1: Add prompt inspector for rendered blueprint
- #8 P2: Migrate PING_PONG from ROLE_PROMPTS to PromptBlueprint

## Notes
Order: Arabic drift → memory validation → seat persistence → header status model → panel/workshop split → memory snapshot → prompt inspector → PING_PONG migration.

The v0.2.1 milestone still needs to be created on the GitHub side and attached to the 8 issues; P0/P1/P2 labels also still need creating if they do not exist yet.