### PR TITLE
P0-2: Reject placeholder fragments before they enter session memory

### DIFF
--- a/scripts/test-session-memory.mjs
+++ b/scripts/test-session-memory.mjs
@@ -16,6 +16,7 @@ const transpiled = ts.transpileModule(source, {
 const moduleUrl = `data:text/javascript;charset=utf-8,${encodeURIComponent(transpiled)}`;
 const {
   createEmptySessionMemory,
+  isPlaceholderMemoryText,
   memoryEntriesFromCheckpoint,
   memoryEntryFromModeratorDecision,
   mergeSessionMemory,
@@ -79,5 +80,39 @@ const selected = selectPromptMemory(merged, 3);
 assert.equal(selected.entries.length, 3);
 assert.equal(selected.entries[0].kind, 'decision');
 assert.match(selected.entries.map(entry => entry.kind).join(','), /fact|risk|question/);
+
+// Placeholder rejection — memory must not accept structural noise or label-only fragments.
+assert.equal(isPlaceholderMemoryText(''), true, 'empty text is a placeholder');
+assert.equal(isPlaceholderMemoryText('* risk_level'), true, 'banned placeholder must be rejected');
+assert.equal(isPlaceholderMemoryText('## Gemini said'), true, 'markdown heading must be rejected');
+assert.equal(isPlaceholderMemoryText('Unresolved Items:'), true, 'label-only line must be rejected');
+assert.equal(isPlaceholderMemoryText('Risk:'), true, 'bare label must be rejected');
+assert.equal(isPlaceholderMemoryText('- '), true, 'lone bullet must be rejected');
+assert.equal(isPlaceholderMemoryText('short'), true, 'too-short text must be rejected');
+assert.equal(
+  isPlaceholderMemoryText('Memory must be inspectable and clearable.'),
+  false,
+  'real conclusion must pass'
+);
+
+const placeholderCheckpoint = {
+  ...checkpoint,
+  id: 'cp_placeholder',
+  artifactSnapshot: {
+    highlights: ['## Gemini said'],
+    ideas: ['- '],
+    risks: ['* risk_level'],
+    questions: ['Unresolved Items:'],
+    decisions: ['Risk:'],
+    synthesis: ''
+  },
+  summary: ''
+};
+const placeholderEntries = memoryEntriesFromCheckpoint(placeholderCheckpoint);
+assert.equal(
+  placeholderEntries.length,
+  0,
+  'a checkpoint whose artifacts are all placeholders must produce zero memory entries'
+);
 
 console.log('session memory tests passed');

--- a/src/background.ts
+++ b/src/background.ts
@@ -473,11 +473,32 @@ function dedupe(items: string[]) {
     return [...new Set(items.filter(Boolean))];
 }
 
+// EN: Skip structural noise so artifact buckets don't capture markdown
+//     headings, lone bullets, or template fragments. The threshold matches
+//     the memory-entry minimum so what we extract survives validation.
+// AR: تجاهل الضوضاء البنيوية حتى لا تلتقط الأقسام عناوين Markdown أو
+//     علامات نقطية فارغة أو قوالب جاهزة.
+const ARTIFACT_LINE_NOISE = /^(?:#{1,6}\s|[-*]\s*$|\d+\.\s*$|>\s*$)/;
+const ARTIFACT_LABEL_ONLY = /^[A-Za-z][A-Za-z _-]*:\s*$/;
+const ARTIFACT_MIN_LENGTH = 20;
+
+function meaningfulContent(line: string): string {
+    return line.replace(/^[-*\d.]+\s*/, '').trim();
+}
+
+function isArtifactLineWorthKeeping(line: string): boolean {
+    if (!line) return false;
+    if (ARTIFACT_LINE_NOISE.test(line)) return false;
+    if (ARTIFACT_LABEL_ONLY.test(line)) return false;
+    if (meaningfulContent(line).length < ARTIFACT_MIN_LENGTH) return false;
+    return true;
+}
+
 function buildArtifacts(transcript: TranscriptEntry[], framing?: SessionFraming): SessionArtifacts {
     const artifacts = emptyArtifacts();
     const assistantTurns = transcript.filter(entry => entry.agent === "Gemini" || entry.agent === "ChatGPT");
     assistantTurns.slice(-8).forEach(entry => {
-        const lines = entry.text.split(/\n+/).map(line => line.trim()).filter(Boolean);
+        const lines = entry.text.split(/\n+/).map(line => line.trim()).filter(isArtifactLineWorthKeeping);
         if (lines[0]) artifacts.highlights.push(lines[0]);
         lines.forEach(line => {
             const lower = line.toLowerCase();

--- a/src/sessionMemory.ts
+++ b/src/sessionMemory.ts
@@ -6,6 +6,32 @@ import type {
 } from './types.js';
 
 const DEFAULT_MEMORY_LIMIT = 24;
+const MIN_MEMORY_TEXT_LENGTH = 20;
+
+// EN: Banned placeholder fragments — these are heading rows or template stubs
+//     leaking from the artifact extractor, not real facts. Reject them
+//     before they enter memory.
+// AR: قوائم محظورة — هذه عناوين أو قوالب فارغة تأتي من مستخرج المخرجات،
+//     وليست حقائق حقيقية. نرفضها قبل دخول الذاكرة.
+const BANNED_PLACEHOLDERS = new Set<string>([
+    "unresolved items",
+    "established facts",
+    "unsupported claims",
+    "risks",
+    "questions",
+    "decisions",
+    "highlights",
+    "ideas",
+    "* risk_level",
+    "## gemini said",
+    "## chatgpt said"
+]);
+
+// Heading-only, bullet-only, or numbered-marker-only lines.
+const STRUCTURAL_NOISE = /^(?:#{1,6}\s|[-*]\s*$|\d+\.\s*$)/;
+
+// "Label:" lines with no content (e.g. "Risk:", "Question:").
+const LABEL_ONLY = /^[A-Za-z][A-Za-z _-]*:\s*$/;
 
 // EN: Session memory stores compact conclusions, not raw transcript history.
 // AR: ذاكرة الجلسة تحفظ خلاصات مركزة، وليس سجل المحادثة الخام.
@@ -15,6 +41,18 @@ export function createEmptySessionMemory(): SessionMemory {
 
 function normalizeText(text: string) {
     return text.trim().replace(/\s+/g, ' ');
+}
+
+// EN: Reject placeholder-shaped text so it never becomes a memory entry.
+// AR: نرفض النصوص ذات الشكل الفارغ حتى لا تدخل الذاكرة.
+export function isPlaceholderMemoryText(text: string): boolean {
+    const clean = normalizeText(text);
+    if (!clean) return true;
+    if (clean.length < MIN_MEMORY_TEXT_LENGTH) return true;
+    if (STRUCTURAL_NOISE.test(clean)) return true;
+    if (LABEL_ONLY.test(clean)) return true;
+    if (BANNED_PLACEHOLDERS.has(clean.toLowerCase())) return true;
+    return false;
 }
 
 export function getMemoryEntryKey(entry: Pick<MemoryEntry, "kind" | "text">) {
@@ -30,7 +68,7 @@ function makeMemoryEntry(
     tags: string[] = []
 ): MemoryEntry | null {
     const clean = normalizeText(text);
-    if (!clean) return null;
+    if (isPlaceholderMemoryText(clean)) return null;
     return { id, kind, text: clean, createdAt, source, tags };
 }
 

--- a/src/studio/tabs/MemoryTab.tsx
+++ b/src/studio/tabs/MemoryTab.tsx
@@ -24,6 +24,13 @@ const KIND_VARIANT: Record<MemoryEntryKind, 'accent' | 'system' | 'paused' | 'es
     assumption: 'system'
 };
 
+const SOURCE_LABEL: Record<string, string> = {
+    checkpoint: 'from checkpoint',
+    moderator: 'from moderator',
+    agent: 'from agent',
+    system: 'from system'
+};
+
 export function MemoryTab() {
     const { selectedSession } = useWorkshopStore();
     const [filter, setFilter] = useState<MemoryEntryKind | 'all'>('all');
@@ -111,7 +118,10 @@ export function MemoryTab() {
                             <Badge variant={KIND_VARIANT[entry.kind]} size="sm">
                                 {KIND_LABEL[entry.kind]}
                             </Badge>
-                            <span className="text-xs text-fg-subtle font-mono">
+                            <span className="text-[10px] uppercase font-mono text-fg-subtle">
+                                {SOURCE_LABEL[entry.source] || entry.source}
+                            </span>
+                            <span className="text-xs text-fg-subtle font-mono ml-auto">
                                 {formatTimestamp(entry.createdAt)}
                             </span>
                         </CardHeader>


### PR DESCRIPTION
## Summary

Memory entries were accepting raw artifacts like \`Risk: * risk_level\`, \`Assumption: ## Gemini said\`, \`Question: Unresolved Items:\`. These came from \`buildArtifacts\` substring-matching transcript lines (which captures markdown headings and template stubs verbatim) and from \`memoryEntriesFromCheckpoint\` blindly taking \`artifacts[bucket][0]\` without validation.

## Changes

- **\`src/sessionMemory.ts\`** — new \`isPlaceholderMemoryText\` validator. Rejects text that is empty, shorter than 20 chars, a markdown heading, a lone bullet/numbered marker, a "Label:"-only line, or in a banned-placeholder list (\`Unresolved Items\`, \`Established Facts\`, \`Risks\`, \`Questions\`, \`Decisions\`, \`* risk_level\`, \`## Gemini said\`, etc.). Wired into \`makeMemoryEntry\`.
- **\`src/background.ts\`** — \`buildArtifacts\` now filters lines through \`isArtifactLineWorthKeeping\`, so the same noise never reaches artifact buckets. Lines that are pure markdown headings, lone bullets, or label-only stubs are skipped before any bucket sees them.
- **\`src/studio/tabs/MemoryTab.tsx\`** — each card now shows a small \`from checkpoint\` / \`from moderator\` source label so users can audit where each fact came from.
- **\`scripts/test-session-memory.mjs\`** — locks the new behaviour: a checkpoint whose artifacts are all placeholders produces zero memory entries; the validator rejects every shape from the audit's bug list.

## Test plan

- [x] \`node scripts/test-session-memory.mjs\` — passes
- [x] All 11 \`scripts/test-*.mjs\` files — pass
- [ ] Manual: run a discussion session and confirm Memory tab no longer shows entries like \`Risk: * risk_level\`

## Risk

Medium. The 20-char floor could empty memory for unusually short conclusions; the threshold is conservative and consistent with the artifact-line floor so what we extract survives memory validation.  Existing test fixtures (real-looking conclusions) continue to pass.

Closes #2.