### PR TITLE
P0-3: Persist AgentSeat on TranscriptEntry; fix escalation-resume duplicate

### DIFF
--- a/scripts/test-runtime-regressions-source.mjs
+++ b/scripts/test-runtime-regressions-source.mjs
@@ -7,6 +7,8 @@ const backgroundSource = readFileSync(resolve('src/background.ts'), 'utf8');
 const contentSource = readFileSync(resolve('src/content.ts'), 'utf8');
 const panelSource = readFileSync(resolve('src/panel.ts'), 'utf8');
 const transcriptSource = readFileSync(resolve('src/transcript.ts'), 'utf8');
+const typesSource = readFileSync(resolve('src/types.ts'), 'utf8');
+const timelineSource = readFileSync(resolve('src/studio/components/Timeline.tsx'), 'utf8');
 
 assert.match(dbSource, /mutateSession/, 'session mutations must use one readwrite transaction');
 assert.doesNotMatch(
@@ -28,8 +30,12 @@ assert.match(backgroundSource, /SAVE_STATE_DEBOUNCE_MS/, 'status logging must de
 assert.match(backgroundSource, /immediate:\s*true/, 'lifecycle transitions must be able to flush state immediately');
 assert.match(backgroundSource, /getRoundSpeakers/, 'discussion loop must alternate transport order by round');
 assert.match(backgroundSource, /consecutiveConvergenceSignals/, 'discussion loop must react to repeated convergence signals');
-assert.match(backgroundSource, /brainstormState\.currentRound--/, 'escalation should not consume a paid round');
+assert.match(backgroundSource, /resumingAfterFirstEscalation/, 'first-turn escalation must reuse the round on resume rather than re-running the first speaker');
+assert.doesNotMatch(backgroundSource, /brainstormState\.currentRound--/, 'escalation must not decrement the round counter — that produces a duplicate first-turn entry');
 assert.match(backgroundSource, /agent: systemFallback \? 'System' : speaker/, 'forced discussion repair fallback must be stored as System output');
+assert.match(backgroundSource, /persistTurn\(\{[\s\S]{0,400}?seat\b/, 'persistTurn calls must include the seat so the workshop never has to recompute it');
+assert.match(typesSource, /seat\?:\s*AgentSeat/, 'TranscriptEntry must carry a persisted seat');
+assert.match(timelineSource, /entry\.seat === 'Agent A' \|\| entry\.seat === 'Agent B'/, 'Timeline must prefer the persisted seat over per-round recomputation');
 assert.match(backgroundSource, /structural discussion guard/i, 'discussion guard should be structural, not broad phrase filtering');
 assert.doesNotMatch(backgroundSource, /"let me know"/, 'discussion guard should not ban common substrings globally');
 assert.doesNotMatch(backgroundSource, /"for you"/, 'discussion guard should not ban common substrings globally');

--- a/src/background.ts
+++ b/src/background.ts
@@ -912,7 +912,12 @@ async function executeAgentTurn(
         intent: brainstormState.currentIntent,
         phase: brainstormState.currentPhase,
         repairStatus,
-        checkpointTag: brainstormState.activeCheckpointId
+        checkpointTag: brainstormState.activeCheckpointId,
+        // EN: Stamp the seat directly so the workshop never has to recompute it
+        //     from agent index. Forced-fallback System turns inherit the seat
+        //     of the agent whose output failed repair.
+        // AR: نحفظ المقعد على الدور مباشرة حتى لا تعيد الواجهة حسابه.
+        seat
     });
 
     if (brainstormState.mode === 'DISCUSSION') {
@@ -936,6 +941,13 @@ async function runBrainstormLoop(runId: string) {
     const activeRole = ROLE_PROMPTS[brainstormState.role] ? brainstormState.role : "CRITIC";
     const roleConfig = ROLE_PROMPTS[activeRole];
     let consecutiveConvergenceSignals = 0;
+    // EN: When the first speaker of a round emits an escalation, the loop
+    //     pauses for human input. On resume we must NOT re-run the first
+    //     speaker (it would persist a duplicate transcript entry under the
+    //     same seat), so we set this flag and skip ahead to the second turn.
+    // AR: عند صدور تصعيد من المتحدث الأول، نتجاوز إعادة تشغيله بعد الاستئناف
+    //     حتى لا يُسجَّل دوران بنفس المقعد.
+    let resumingAfterFirstEscalation = false;
     log(`Loop started with role: ${activeRole}`);
 
     const noteConvergence = (turn: { converged?: boolean; systemFallback?: boolean }) => {
@@ -954,10 +966,12 @@ async function runBrainstormLoop(runId: string) {
 
     try {
         while (brainstormState.active && activeRunId === runId && brainstormState.currentRound < brainstormState.rounds) {
-            brainstormState.currentRound++;
-            brainstormState.currentPhase = getPhase(brainstormState.currentRound, brainstormState.rounds);
-            saveState();
-            log(`Round ${brainstormState.currentRound} initiating in phase ${brainstormState.currentPhase}...`);
+            if (!resumingAfterFirstEscalation) {
+                brainstormState.currentRound++;
+                brainstormState.currentPhase = getPhase(brainstormState.currentRound, brainstormState.rounds);
+                saveState();
+                log(`Round ${brainstormState.currentRound} initiating in phase ${brainstormState.currentPhase}...`);
+            }
 
             while (brainstormState.isPaused && brainstormState.active && activeRunId === runId) await wait(1000);
             if (!brainstormState.active || activeRunId !== runId) break;
@@ -969,25 +983,41 @@ async function runBrainstormLoop(runId: string) {
             const firstSeat = getSeatForTurn(firstSpeaker, firstSpeaker);
             const secondSeat = getSeatForTurn(secondSpeaker, firstSpeaker);
 
-            const firstTurn = await executeAgentTurn(firstSpeaker, firstSeat, brainstormState.currentRound === 1, roleConfig, framing, promptMemory, session?.topic);
-            if (!brainstormState.active || activeRunId !== runId) break;
-            if (firstTurn.escalated) {
-                brainstormState.currentRound--;
-                continue;
+            let firstOutput: string;
+            let firstConverged = false;
+            let firstSystemFallback = false;
+            if (resumingAfterFirstEscalation) {
+                resumingAfterFirstEscalation = false;
+                // The first speaker already produced (and persisted) the escalation
+                // turn last iteration. The human's resolution lives in resumeContext
+                // and will be folded into the second turn's prompt by executeAgentTurn.
+                firstOutput = brainstormState.prompt;
+            } else {
+                const firstTurn = await executeAgentTurn(firstSpeaker, firstSeat, brainstormState.currentRound === 1, roleConfig, framing, promptMemory, session?.topic);
+                if (!brainstormState.active || activeRunId !== runId) break;
+                if (firstTurn.escalated) {
+                    resumingAfterFirstEscalation = true;
+                    continue;
+                }
+                firstOutput = firstTurn.output;
+                firstConverged = !!firstTurn.converged;
+                firstSystemFallback = !!firstTurn.systemFallback;
             }
 
             await wait(1500);
             while (brainstormState.isPaused && brainstormState.active && activeRunId === runId) await wait(1000);
             if (!brainstormState.active || activeRunId !== runId) break;
-            const secondTurn = await executeAgentTurn(secondSpeaker, secondSeat, false, roleConfig, framing, promptMemory, session?.topic, firstTurn.output);
+            const secondTurn = await executeAgentTurn(secondSpeaker, secondSeat, false, roleConfig, framing, promptMemory, session?.topic, firstOutput);
             if (!brainstormState.active || activeRunId !== runId) break;
             if (secondTurn.escalated) {
-                brainstormState.currentRound--;
+                // Second-turn escalation: do NOT decrement currentRound. The next
+                // iteration will start a fresh round, avoiding the duplicate-first-turn
+                // shape that the old `currentRound--` produced.
                 continue;
             }
 
             await maybeCreateCheckpoint(secondTurn.output);
-            if (noteConvergence(firstTurn) || noteConvergence(secondTurn)) break;
+            if (noteConvergence({ converged: firstConverged, systemFallback: firstSystemFallback }) || noteConvergence(secondTurn)) break;
             await wait(1500);
         }
     } catch (err: any) {

--- a/src/studio/components/Timeline.tsx
+++ b/src/studio/components/Timeline.tsx
@@ -8,13 +8,16 @@ import { cn, formatTimestamp } from '../lib/utils.js';
 
 type Seat = 'Agent A' | 'Agent B' | 'System' | 'User';
 
-// Mirrors getSeatForEntry in src/studio.ts (the legacy logic): seats alternate
-// per round, so the same agent (Gemini or ChatGPT) plays Agent A on odd rounds
-// and Agent B on even rounds.  Computing it from the transcript order keeps
-// the seat label correct without us needing to persist it on TranscriptEntry.
+// Prefer the seat persisted on the entry (issue #3). Fall back to the legacy
+// per-round alternation only for sessions saved before seat persistence
+// landed: round-N first speaker is always Agent A, second is Agent B, with
+// Gemini/ChatGPT swapping which seat they hold each round.
 function getSeat(entry: TranscriptEntry, agentTurnIndex: number, firstSpeaker: string): Seat {
-    if (entry.agent === 'System') return 'System';
     if (entry.agent === 'User') return 'User';
+    // Forced-fallback System turns inherit the seat of the agent whose output
+    // failed; honour that so the timeline tints them correctly.
+    if (entry.seat === 'Agent A' || entry.seat === 'Agent B') return entry.seat;
+    if (entry.agent === 'System') return 'System';
     const round = Math.floor(agentTurnIndex / 2) + 1;
     const roundFirst = round % 2 === 1
         ? firstSpeaker

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,12 @@ export interface TranscriptEntry {
     phase?: SessionPhase;
     repairStatus?: RepairStatus;
     checkpointTag?: string | null;
+    // EN: Persisted seat ("Agent A" / "Agent B") so the workshop never has to
+    //     recompute it from the turn index. System fallback turns inherit the
+    //     seat of the agent whose output failed repair.
+    // AR: حفظ المقعد ("Agent A" / "Agent B") مباشرة على الدور حتى لا تعيد
+    //     الواجهة حسابه من ترتيب الأدوار.
+    seat?: AgentSeat;
 }
 
 export interface EscalationPayload {


### PR DESCRIPTION
## Summary

Two related fixes:

1. \`TranscriptEntry\` now carries a persisted \`seat?: AgentSeat\`. The Workshop Timeline reads it directly instead of recomputing from agent index.
2. The escalation/resume flow no longer decrements \`currentRound\` and re-runs the first speaker. Both behaviours together produced the bug where the same model showed up as both Agent A and Agent B in one round.

## Changes

- **\`src/types.ts\`** — \`TranscriptEntry.seat?: AgentSeat\`.
- **\`src/background.ts\`** — \`executeAgentTurn\` stamps \`seat\` on every persisted turn. Forced-fallback System turns inherit the seat of the agent whose output failed repair.
- **\`src/background.ts\`** — \`runBrainstormLoop\` replaces \`currentRound--; continue\` with a \`resumingAfterFirstEscalation\` flag. First-turn escalation no longer re-runs the first speaker after resume; the human's resolution (in \`resumeContext\`) folds into the second turn. Second-turn escalation \`continue\`s without decrement, so the next round starts fresh.
- **\`src/studio/components/Timeline.tsx\`** — \`getSeat\` prefers \`entry.seat\` first; the per-round recompute remains as a fallback for sessions saved before this PR.
- **\`scripts/test-runtime-regressions-source.mjs\`** — locks: no \`currentRound--\`, \`resumingAfterFirstEscalation\` flag exists, \`persistTurn\` carries seat, \`TranscriptEntry\` defines seat, Timeline reads \`entry.seat\`.

## Test plan

- [x] All 11 \`scripts/test-*.mjs\` files — pass
- [ ] Manual: trigger an escalation on round-2 first turn, resume with feedback, confirm round 2 has exactly two entries (escalation by speaker A, response by speaker B) and no duplicate-A turn

## Risk

Medium. Persisted shape adds an optional field; old sessions still render via the legacy fallback. The escalation-loop refactor is the more delicate part — first-turn escalation was the audit's reported bug; second-turn escalation is also fixed similarly.

Closes #3.