### PR TITLE
P0-4: Split lifecycle status from phase/intent in Workshop header

### DIFF
--- a/scripts/test-studio-workshop-source.mjs
+++ b/scripts/test-studio-workshop-source.mjs
@@ -62,6 +62,19 @@ assert.match(studioCss, /\.prose-studio/, 'studio.css must define prose-studio m
 assert.match(studioCss, /padding-inline-start/, 'prose-studio must use logical properties for RTL correctness');
 
 // ---------------------------------------------------------------------------
+// Header status model — lifecycle separated from phase / intent.
+// ---------------------------------------------------------------------------
+const header = readFileSync(resolve('src/studio/components/Header.tsx'), 'utf8');
+assert.match(header, /deriveLifecycle/, 'Header must derive a lifecycle status (idle/running/paused/finished)');
+assert.match(header, /finished/, 'Header must distinguish a finished session from idle');
+assert.match(header, /DIVERGE: 'Explore'/, 'Header must use friendly phase names (DIVERGE → Explore)');
+assert.match(header, /CONVERGE: 'Narrow'/, 'Header must use friendly phase names (CONVERGE → Narrow)');
+assert.match(header, /FINALIZE: 'Finalize'/, 'Header must use friendly phase names (FINALIZE → Finalize)');
+assert.match(header, /lastTurnPhase/, 'Header must derive the displayed phase from the last completed turn when finished');
+assert.doesNotMatch(header, /breadcrumbParts\.push\(state\.currentIntent\)/, 'Header must not show the raw current intent string');
+assert.doesNotMatch(header, /breadcrumbParts\.push\(state\.currentPhase\)/, 'Header must not show the raw current phase string');
+
+// ---------------------------------------------------------------------------
 // Component composition: the App tree must include all the major pieces.
 // ---------------------------------------------------------------------------
 const appPath = resolve('src/studio/App.tsx');

--- a/src/studio/components/Header.tsx
+++ b/src/studio/components/Header.tsx
@@ -2,22 +2,87 @@ import { useWorkshopStore } from '../store/workshop.js';
 import { pauseBrainstorm, resumeBrainstorm, stopBrainstorm } from '../lib/extension.js';
 import { Button } from '../ui/button.js';
 import { Badge } from '../ui/badge.js';
+import type { BrainstormState, SessionPhase, TurnIntent } from '../../types.js';
+
+// Friendly names map raw enum strings to user-facing copy.  Keep these in sync
+// with the audit's recommended copy table (issue #4 / v0.2.1).
+const PHASE_LABEL: Record<SessionPhase, string> = {
+    DIVERGE: 'Explore',
+    CONVERGE: 'Narrow',
+    FINALIZE: 'Finalize'
+};
+
+const MOVE_LABEL: Record<TurnIntent, string> = {
+    expand: 'Expand',
+    critique: 'Critique',
+    verify: 'Verify',
+    combine: 'Combine',
+    narrow: 'Narrow',
+    conclude: 'Conclude',
+    escalate: 'Escalation',
+    synthesize: 'Synthesize',
+    moderate: 'Moderator'
+};
+
+type Lifecycle = 'idle' | 'running' | 'paused' | 'finished';
+
+function deriveLifecycle(state: BrainstormState): Lifecycle {
+    if (state.active) return state.isPaused ? 'paused' : 'running';
+    return state.sessionId ? 'finished' : 'idle';
+}
+
+const LIFECYCLE_LABEL: Record<Lifecycle, string> = {
+    idle: 'Idle',
+    running: 'Running',
+    paused: 'Paused',
+    finished: 'Finished'
+};
 
 export function Header() {
-    const { state, refresh } = useWorkshopStore();
+    const { state, selectedSession, refresh } = useWorkshopStore();
 
-    const stateLabel = state.active ? (state.isPaused ? 'Paused' : 'Running') : 'Idle';
-    const stateVariant: 'running' | 'paused' | 'idle' | 'escalation' = state.awaitingHumanDecision
+    const lifecycle = deriveLifecycle(state);
+    // While running we trust the engine's currentPhase (it points at the
+    // *next* turn's phase, which is what the user wants live).  Once the run
+    // is over, currentPhase freezes and contradicts the transcript — derive
+    // session phase from the last completed turn instead.
+    const lastTurnPhase = (() => {
+        const transcript = selectedSession?.transcript || [];
+        for (let i = transcript.length - 1; i >= 0; i--) {
+            const phase = transcript[i].phase;
+            if (phase) return phase;
+        }
+        return undefined;
+    })();
+    const phaseToShow: SessionPhase | undefined =
+        lifecycle === 'running' || lifecycle === 'paused'
+            ? state.currentPhase
+            : lifecycle === 'finished'
+                ? lastTurnPhase
+                : undefined;
+
+    const moveToShow: TurnIntent | undefined =
+        lifecycle === 'running' || lifecycle === 'paused'
+            ? state.currentIntent
+            : undefined;
+
+    const stateVariant: 'running' | 'paused' | 'idle' | 'escalation' | 'success' = state.awaitingHumanDecision
         ? 'escalation'
-        : state.active
-            ? state.isPaused ? 'paused' : 'running'
-            : 'idle';
+        : lifecycle === 'running'
+            ? 'running'
+            : lifecycle === 'paused'
+                ? 'paused'
+                : lifecycle === 'finished'
+                    ? 'success'
+                    : 'idle';
 
-    const breadcrumbParts: string[] = [stateLabel];
+    const breadcrumbParts: string[] = [LIFECYCLE_LABEL[lifecycle]];
     if (state.sessionId) {
-        breadcrumbParts.push(`Round ${state.currentRound}/${state.rounds}`);
-        breadcrumbParts.push(state.currentPhase);
-        breadcrumbParts.push(state.currentIntent);
+        if (lifecycle === 'running' || lifecycle === 'paused' || lifecycle === 'finished') {
+            breadcrumbParts.push(`${state.currentRound} of ${state.rounds}`);
+        }
+        if (phaseToShow) breadcrumbParts.push(`Phase: ${PHASE_LABEL[phaseToShow]}`);
+        if (moveToShow) breadcrumbParts.push(`Move: ${MOVE_LABEL[moveToShow]}`);
     } else {
         breadcrumbParts.push('No active session');
     }
@@ -39,7 +104,9 @@ export function Header() {
             </div>
 
             <div className="flex flex-wrap items-center gap-2">
-                <Badge id="globalStateBadge" variant={stateVariant}>{stateLabel}</Badge>
+                <Badge id="globalStateBadge" variant={stateVariant}>
+                    {LIFECYCLE_LABEL[lifecycle]}
+                </Badge>
                 {state.awaitingHumanDecision && (
                     <Badge variant="escalation">Escalation pending</Badge>
                 )}


### PR DESCRIPTION
## Summary

The Workshop header was conflating four orthogonal axes (\`active/paused\`, \`currentRound/rounds\`, \`currentPhase\`, \`currentIntent\`) into one breadcrumb. After the convergence-driven early stop in \`runBrainstormLoop\`, \`currentPhase\` and \`currentIntent\` froze at \`FINALIZE\`/\`critique\` while the transcript still showed \`DIVERGE\` turns, producing the contradiction the audit reported: \`Idle · Round 4/7 · FINALIZE · critique\`.

## Changes

- **\`src/studio/components/Header.tsx\`** — \`deriveLifecycle\` returns \`idle | running | paused | finished\`. \`finished\` is what we previously called \`idle\` when a session existed.
- **\`Header\`** — round shown as \`N of M\` (only when a session exists). Phase derived from the last completed transcript entry's \`phase\` when the run is over; \`state.currentPhase\` only used while running/paused. \`Move\` hidden when not active.
- **\`Header\`** — friendly names: \`DIVERGE → Explore\`, \`CONVERGE → Narrow\`, \`FINALIZE → Finalize\`, intents → title case. Matches the v0.2.1 copy table.
- **\`scripts/test-studio-workshop-source.mjs\`** — locks the new copy and the lifecycle derivation; explicitly forbids pushing \`state.currentIntent\` / \`state.currentPhase\` into the breadcrumb.

## Test plan

- [x] All 11 \`scripts/test-*.mjs\` files — pass
- [x] \`tsc --noEmit\` — clean
- [ ] Manual: run a session that early-stops on convergence at round 3 of 7 and confirm the header reads \`Finished · 3 of 7 · Phase: Explore\` (not \`Idle · Round 4/7 · FINALIZE · critique\`)
- [ ] Manual: while running, header reads \`Running · Round 3 of 7 · Phase: Narrow · Move: Verify\`

## Risk

Low. Pure presentation change. The breadcrumb DOM ID \`studioBreadcrumb\` is preserved (locked by \`test-studio-workshop-source.mjs\`).

Closes #4.