### PR TITLE
P1-6: Persist actually-sent prompt memory snapshot per turn

### DIFF
--- a/scripts/test-runtime-regressions-source.mjs
+++ b/scripts/test-runtime-regressions-source.mjs
@@ -33,9 +33,11 @@ assert.match(backgroundSource, /consecutiveConvergenceSignals/, 'discussion loop
 assert.match(backgroundSource, /resumingAfterFirstEscalation/, 'first-turn escalation must reuse the round on resume rather than re-running the first speaker');
 assert.doesNotMatch(backgroundSource, /brainstormState\.currentRound--/, 'escalation must not decrement the round counter — that produces a duplicate first-turn entry');
 assert.match(backgroundSource, /agent: systemFallback \? 'System' : speaker/, 'forced discussion repair fallback must be stored as System output');
-assert.match(backgroundSource, /persistTurn\(\{[\s\S]{0,400}?seat\b/, 'persistTurn calls must include the seat so the workshop never has to recompute it');
+assert.match(backgroundSource, /persistTurn\(\{[\s\S]{0,500}?seat\b/, 'persistTurn calls must include the seat so the workshop never has to recompute it');
 assert.match(typesSource, /seat\?:\s*AgentSeat/, 'TranscriptEntry must carry a persisted seat');
 assert.match(timelineSource, /entry\.seat === 'Agent A' \|\| entry\.seat === 'Agent B'/, 'Timeline must prefer the persisted seat over per-round recomputation');
+assert.match(typesSource, /promptMemorySnapshot\?:\s*MemoryEntry\[\]/, 'TranscriptEntry must carry the memory snapshot actually used in this turn');
+assert.match(backgroundSource, /promptMemorySnapshot:\s*brainstormState\.mode === "DISCUSSION"/, 'persistTurn must stamp the memory snapshot from the same memory that was rendered into the prompt');
 assert.match(backgroundSource, /structural discussion guard/i, 'discussion guard should be structural, not broad phrase filtering');
 assert.doesNotMatch(backgroundSource, /"let me know"/, 'discussion guard should not ban common substrings globally');
 assert.doesNotMatch(backgroundSource, /"for you"/, 'discussion guard should not ban common substrings globally');

--- a/src/background.ts
+++ b/src/background.ts
@@ -946,7 +946,14 @@ async function executeAgentTurn(
         //     from agent index. Forced-fallback System turns inherit the seat
         //     of the agent whose output failed repair.
         // AR: نحفظ المقعد على الدور مباشرة حتى لا تعيد الواجهة حسابه.
-        seat
+        seat,
+        // EN: Snapshot the memory entries that were actually folded into this
+        //     turn's blueprint.  PING_PONG mode does not yet read memory into
+        //     prompts (issue #8), so we only stamp the snapshot for DISCUSSION
+        //     to keep the UI honest about what was sent.
+        // AR: نحفظ مدخلات الذاكرة المُرسَلة فعلاً في هذا الدور (وضع DISCUSSION
+        //     فقط؛ سيُفعَّل وضع PING_PONG عند مهاجرته إلى blueprint).
+        promptMemorySnapshot: brainstormState.mode === "DISCUSSION" ? (memory?.entries || []) : undefined
     });
 
     if (brainstormState.mode === 'DISCUSSION') {

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,12 @@ export interface TranscriptEntry {
     // AR: حفظ المقعد ("Agent A" / "Agent B") مباشرة على الدور حتى لا تعيد
     //     الواجهة حسابه من ترتيب الأدوار.
     seat?: AgentSeat;
+    // EN: The exact memory entries that were folded into this turn's prompt.
+    //     Lets the UI display "memory sent to agents this turn" from
+    //     authoritative state instead of recomputing.
+    // AR: مدخلات الذاكرة التي أُدرجت فعلياً في مطالبة هذا الدور — حتى
+    //     تعرض الواجهة ما أُرسل بالضبط بدلاً من إعادة الحساب.
+    promptMemorySnapshot?: MemoryEntry[];
 }
 
 export interface EscalationPayload {


### PR DESCRIPTION
## Summary

The "Prompt-Used Memory" preview in the side panel was recomputed from the saved session by \`panel.ts\`, while the orchestrator independently called \`selectPromptMemory\` in \`runBrainstormLoop\`. Two independent calls to the same selector against the same data should match — but they can drift if memory changes between calls or selector parameters diverge later, so the panel was not authoritative.

## Changes

- **\`src/types.ts\`** — \`TranscriptEntry.promptMemorySnapshot?: MemoryEntry[]\`.
- **\`src/background.ts\`** — \`executeAgentTurn\` stamps the snapshot from the same \`memory\` argument that was passed to \`buildDiscussionBlueprint\`, capturing exactly what was folded into the rendered prompt.
- **Mode gating** — PING_PONG mode does not yet read memory into prompts (issue #8). To keep the snapshot honest about what was actually sent, the field is left undefined for PING_PONG turns.
- **\`scripts/test-runtime-regressions-source.mjs\`** — locks the new contract.

UI consumers (the panel "Memory sent to agents this turn" preview, an optional per-turn snapshot view in the Workshop timeline) can now read from \`entry.promptMemorySnapshot\` rather than recomputing.

## Test plan

- [x] All 11 \`scripts/test-*.mjs\` files — pass
- [x] \`tsc --noEmit\` — clean
- [ ] Manual: run a DISCUSSION session and confirm new transcript entries carry \`promptMemorySnapshot\`; confirm PING_PONG turns leave the field undefined

## Risk

Low. Storage delta per turn is small (capped to 8 entries by \`selectPromptMemory\` defaults). Old sessions render fine — the field is optional.

Closes #6.