### PR TITLE
P1-7: Add prompt inspector for the rendered blueprint

### DIFF
--- a/scripts/test-runtime-regressions-source.mjs
+++ b/scripts/test-runtime-regressions-source.mjs
@@ -38,6 +38,10 @@ assert.match(typesSource, /seat\?:\s*AgentSeat/, 'TranscriptEntry must carry a p
 assert.match(timelineSource, /entry\.seat === 'Agent A' \|\| entry\.seat === 'Agent B'/, 'Timeline must prefer the persisted seat over per-round recomputation');
 assert.match(typesSource, /promptMemorySnapshot\?:\s*MemoryEntry\[\]/, 'TranscriptEntry must carry the memory snapshot actually used in this turn');
 assert.match(backgroundSource, /promptMemorySnapshot:\s*brainstormState\.mode === "DISCUSSION"/, 'persistTurn must stamp the memory snapshot from the same memory that was rendered into the prompt');
+assert.match(typesSource, /promptSnapshot\?:\s*string/, 'TranscriptEntry must carry the rendered prompt for inspection');
+assert.match(backgroundSource, /promptSnapshot:\s*prompt/, 'persistTurn must capture the canonical prompt that produced this turn');
+assert.match(timelineSource, /entry\.promptSnapshot/, 'Timeline must surface the prompt snapshot via a Show prompt affordance');
+assert.match(timelineSource, /Show prompt/, 'Timeline must label the prompt-inspection toggle "Show prompt"');
 assert.match(backgroundSource, /structural discussion guard/i, 'discussion guard should be structural, not broad phrase filtering');
 assert.doesNotMatch(backgroundSource, /"let me know"/, 'discussion guard should not ban common substrings globally');
 assert.doesNotMatch(backgroundSource, /"for you"/, 'discussion guard should not ban common substrings globally');

--- a/src/background.ts
+++ b/src/background.ts
@@ -953,7 +953,12 @@ async function executeAgentTurn(
         //     to keep the UI honest about what was sent.
         // AR: نحفظ مدخلات الذاكرة المُرسَلة فعلاً في هذا الدور (وضع DISCUSSION
         //     فقط؛ سيُفعَّل وضع PING_PONG عند مهاجرته إلى blueprint).
-        promptMemorySnapshot: brainstormState.mode === "DISCUSSION" ? (memory?.entries || []) : undefined
+        promptMemorySnapshot: brainstormState.mode === "DISCUSSION" ? (memory?.entries || []) : undefined,
+        // EN: Capture the canonical prompt for this turn.  Repair / regenerate
+        //     prompts inside sanitizeDiscussionOutput are NOT captured — only
+        //     the main prompt that produced the persisted output.
+        // AR: نلتقط المطالبة الأساسية لهذا الدور (لا مطالبات الإصلاح).
+        promptSnapshot: prompt
     });
 
     if (brainstormState.mode === 'DISCUSSION') {

--- a/src/studio/components/Timeline.tsx
+++ b/src/studio/components/Timeline.tsx
@@ -144,6 +144,16 @@ function TurnRow({ item }: { item: TimelineEntry }) {
                     )}
                 </header>
                 <MarkdownBody text={entry.text} />
+                {entry.promptSnapshot && (
+                    <details className="text-xs text-fg-subtle">
+                        <summary className="cursor-pointer select-none font-mono uppercase text-[10px]">
+                            Show prompt
+                        </summary>
+                        <pre className="mt-2 max-h-[400px] overflow-auto whitespace-pre-wrap rounded-md border border-border bg-bg/60 p-2 text-[11px] text-fg-muted">
+                            {entry.promptSnapshot}
+                        </pre>
+                    </details>
+                )}
             </div>
         </article>
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,6 +103,13 @@ export interface TranscriptEntry {
     // AR: مدخلات الذاكرة التي أُدرجت فعلياً في مطالبة هذا الدور — حتى
     //     تعرض الواجهة ما أُرسل بالضبط بدلاً من إعادة الحساب.
     promptMemorySnapshot?: MemoryEntry[];
+    // EN: The exact prompt that was sent to produce this turn (rendered
+    //     blueprint for DISCUSSION, or the role-prompt template for
+    //     PING_PONG).  Lets the workshop's Show prompt affordance display
+    //     authoritative state, not a re-render.
+    // AR: المطالبة الفعلية المرسلة لهذا الدور — حتى يعرضها مفتش المطالبات
+    //     في الواجهة كما هي بدلاً من إعادة بنائها.
+    promptSnapshot?: string;
 }
 
 export interface EscalationPayload {


### PR DESCRIPTION
## Summary

The layered prompt blueprint runs in DISCUSSION mode but is invisible to the user. There was no way to see exactly what was sent for a given turn, verify which memory entries made it into the prompt, or debug why an agent drifted. This makes the layered architecture visible.

## Changes

- **\`src/types.ts\`** — \`TranscriptEntry.promptSnapshot?: string\` (the canonical prompt rendered for this turn, post phase-guidance, post forced-convergence control instruction). Repair/regenerate prompts inside \`sanitizeDiscussionOutput\` are intentionally NOT captured; only the primary prompt that produced the persisted output is.
- **\`src/background.ts\`** — \`executeAgentTurn\` stamps the snapshot from the same \`prompt\` string that was passed to \`sendPromptToTab\`.
- **\`src/studio/components/Timeline.tsx\`** — small native \`<details>\`/\`<summary>\` "Show prompt" affordance per turn. Hidden by default, opt-in per card — no extra Radix dependency. Snapshot rendered in a scroll-bounded \`<pre>\`.
- **\`scripts/test-runtime-regressions-source.mjs\`** — locks: \`TranscriptEntry\` defines \`promptSnapshot\`, \`persistTurn\` captures \`prompt\`, Timeline references \`entry.promptSnapshot\`, the affordance label is "Show prompt".

## Test plan

- [x] All 11 \`scripts/test-*.mjs\` files — pass
- [x] \`tsc --noEmit\` — clean
- [ ] Manual: run a DISCUSSION turn, click "Show prompt" on the new turn card, confirm the six-layer blueprint structure (\`[SYSTEM PROTOCOL]\` ... \`[OUTPUT CONTRACT]\`) is visible
- [ ] Manual: run a PING_PONG turn, confirm the role-prompt template is visible

## Risk

Medium. Storage cost is the main concern; rendered prompts can be several KB each. For now stored uncapped; if storage becomes a problem we can truncate or compress in a follow-up.

Closes #7.