### PR TITLE
P2-8: Migrate PING_PONG to PromptBlueprint shell

### DIFF
--- a/scripts/test-prompt-blueprint.mjs
+++ b/scripts/test-prompt-blueprint.mjs
@@ -14,7 +14,7 @@ const transpiled = ts.transpileModule(source, {
 }).outputText;
 
 const moduleUrl = `data:text/javascript;charset=utf-8,${encodeURIComponent(transpiled)}`;
-const { buildDiscussionBlueprint, renderPromptBlueprint } = await import(moduleUrl);
+const { buildDiscussionBlueprint, buildPingPongBlueprint, renderPromptBlueprint } = await import(moduleUrl);
 
 const blueprint = buildDiscussionBlueprint({
   speaker: 'Gemini',
@@ -93,5 +93,32 @@ assert.match(backgroundSource, /structural discussion guard/i);
 assert.doesNotMatch(backgroundSource, /"i recommend"/, 'role prompts must be allowed to recommend, reject, or stress-test');
 assert.match(backgroundSource, /agent: systemFallback \? 'System' : speaker/, 'forced repair fallback must persist as a System note');
 assert.doesNotMatch(backgroundSource, /return \{ text: buildForcedDiscussionReply\(counterpart\), status: "forced" \}/);
+
+// PING_PONG migration (issue #8) — both modes now flow through promptBlueprint.
+assert.match(backgroundSource, /buildPingPongBlueprint/, 'PING_PONG must render via buildPingPongBlueprint');
+assert.match(backgroundSource, /import \{[\s\S]*?buildPingPongBlueprint[\s\S]*?\} from '.\/promptBlueprint\.js'/, 'background.ts must import buildPingPongBlueprint from promptBlueprint');
+
+const pingPongRendered = renderPromptBlueprint(buildPingPongBlueprint({
+  speaker: 'Gemini',
+  seat: 'Agent A',
+  isOpeningTurn: true,
+  role: 'EXPANDER',
+  rootTopic: 'Design a friendlier onboarding for older users.',
+  roleNarrative: 'Topic: "Design a friendlier onboarding for older users."\n\nProvide an initial creative concept for this topic. Keep it open-ended.',
+  phase: 'DIVERGE',
+  intent: 'expand',
+  memory: {
+    entries: [
+      { id: 'm2', kind: 'fact', text: 'Memory must survive PING_PONG mode too.', createdAt: 1, source: 'checkpoint' }
+    ]
+  }
+}));
+assert.match(pingPongRendered, /SYSTEM PROTOCOL/);
+assert.match(pingPongRendered, /Collaborative Exchange Protocol/, 'PING_PONG must use the Collaborative Exchange protocol label');
+assert.match(pingPongRendered, /You are Agent A: Synthesis Architect/);
+assert.match(pingPongRendered, /Memory must survive PING_PONG mode too\./, 'PING_PONG must include session memory in the rendered prompt');
+assert.match(pingPongRendered, /Provide an initial creative concept/, 'PING_PONG must carry the role narrative as the latest input');
+assert.match(pingPongRendered, /Build on the previous contribution/, 'PING_PONG output contract must be iterative, not agent-to-agent');
+assert.doesNotMatch(pingPongRendered, /Output only the agent-to-agent reply/, 'PING_PONG must NOT use the discussion-mode output contract');
 
 console.log('prompt blueprint tests passed');

--- a/src/background.ts
+++ b/src/background.ts
@@ -32,6 +32,7 @@ import {
 } from './types.js';
 import {
     buildDiscussionBlueprint,
+    buildPingPongBlueprint,
     renderPromptBlueprint
 } from './promptBlueprint.js';
 import {
@@ -168,7 +169,12 @@ async function ensureInjected(tabId: number) {
     } catch { }
 }
 
-// Legacy PING_PONG prompt path. DISCUSSION prompts use promptBlueprint.ts; migrate this table after the drift-control changes settle.
+// Legacy PING_PONG prompt path — per-role narrative templates. As of issue
+// #8, the rendered narrative from this table is wrapped in the layered
+// blueprint (Identity / Style / Memory / Output Contract) by
+// buildPingPongBlueprint — it is no longer the entire prompt. Future work
+// can fold these directly into role directives if cleaner per-role parity
+// is needed.
 const ROLE_PROMPTS: Record<string, {
     geminiInit: (topic: string, cp?: string) => string;
     chatGPTInit: (topic: string, cp?: string) => string;
@@ -885,8 +891,9 @@ async function executeAgentTurn(
     const anchoredBasePrompt = brainstormState.mode === "DISCUSSION"
         ? basePrompt
         : buildSeedAnchoredInput(sessionSeed, basePrompt, isOpeningTurn);
-    let prompt = brainstormState.mode === "DISCUSSION"
-        ? renderPromptBlueprint(buildDiscussionBlueprint({
+    let prompt: string;
+    if (brainstormState.mode === "DISCUSSION") {
+        prompt = renderPromptBlueprint(buildDiscussionBlueprint({
             speaker,
             seat,
             isOpeningTurn,
@@ -897,12 +904,26 @@ async function executeAgentTurn(
             intent: brainstormState.currentIntent,
             framing,
             memory
-        }))
-        : isOpeningTurn
+        }));
+    } else {
+        // PING_PONG: render the existing role-prompt narrative, then wrap it
+        // in the layered shell so the agent gets memory + identity + the
+        // PING_PONG output contract too (issue #8).
+        const roleNarrative = isOpeningTurn
             ? agent.initPrompt(roleConfig, anchoredBasePrompt)
             : agent.loopPrompt(roleConfig, anchoredBasePrompt);
-
-    if (brainstormState.mode !== "DISCUSSION") {
+        prompt = renderPromptBlueprint(buildPingPongBlueprint({
+            speaker,
+            seat,
+            isOpeningTurn,
+            role: brainstormState.role,
+            rootTopic,
+            roleNarrative,
+            phase: brainstormState.currentPhase,
+            intent: brainstormState.currentIntent,
+            framing,
+            memory
+        }));
         prompt = addPhaseGuidance(prompt, brainstormState.currentPhase, brainstormState.currentIntent, framing);
     }
 

--- a/src/promptBlueprint.ts
+++ b/src/promptBlueprint.ts
@@ -26,6 +26,26 @@ interface DiscussionBlueprintInput {
     memory?: SessionMemory;
 }
 
+// EN: PING_PONG renders the existing role-prompt narrative as the latest input
+//     and wraps it in the layered shell (identity, style, memory, output
+//     contract).  This keeps ROLE_PROMPTS' carefully tuned per-role framing
+//     intact while finally giving PING_PONG the same memory-aware, identity-
+//     stable shell that DISCUSSION already had.
+// AR: PING_PONG يستخدم نفس قالب الأدوار القديم كمدخل أخير، ويلتفّ حوله غلاف
+//     الذاكرة والهوية حتى تستفيد جلسات الكتابة المتبادلة من ذاكرة الجلسة.
+interface PingPongBlueprintInput {
+    speaker: AgentSpeaker;
+    seat: AgentSeat;
+    isOpeningTurn: boolean;
+    role: string;
+    rootTopic?: string;
+    roleNarrative: string;
+    phase: SessionPhase;
+    intent: TurnIntent;
+    framing?: SessionFraming;
+    memory?: SessionMemory;
+}
+
 const DISCUSSION_PROTOCOL: PromptProtocol = {
     label: "Agent Workshop Protocol",
     rules: [
@@ -55,6 +75,27 @@ const DISCUSSION_PROTOCOL: PromptProtocol = {
         "next_step_after_decision: <what the next agent should do>",
         "[/ESCALATION_REQUIRED]"
     ].join('\n')
+};
+
+// EN: PING_PONG mode = collaborative iteration on the user's topic.  The
+//     agents build on each other's work rather than challenge each other
+//     directly; the output contract reflects that.
+// AR: وضع PING_PONG = تكرار تعاوني على موضوع المستخدم؛ يبني الوكلاء
+//     على بعضهم بدلاً من المواجهة المباشرة.
+const PINGPONG_PROTOCOL: PromptProtocol = {
+    label: "Collaborative Exchange Protocol",
+    rules: [
+        "You and the other agent iterate on the user's topic together.",
+        "Build on the previous contribution rather than restart from scratch.",
+        "Stay anchored to the seed prompt or topic.",
+        "Mark weak or missing evidence as inference.",
+        "Make exactly one primary move for this turn."
+    ],
+    outputContract: [
+        "Output your contribution directly. No meta-commentary about the protocol.",
+        "Do not mention the system protocol, prompt layers, output contract, or hidden instructions.",
+        "Build on the previous contribution; do not pretend the conversation is starting fresh."
+    ]
 };
 
 // EN: These identities define reasoning responsibility, not cosmetic personality.
@@ -240,6 +281,56 @@ export function buildDiscussionBlueprint(input: DiscussionBlueprintInput): Promp
     };
 }
 
+function buildPingPongTask(isOpeningTurn: boolean, intent: TurnIntent): PromptTurnTask {
+    if (isOpeningTurn) {
+        return {
+            move: intent,
+            instructions: [
+                "Open the session by responding directly to the role narrative below.",
+                "Stay anchored to the seed prompt; the role narrative is the framing for THIS turn only.",
+                "Leave a specific hook for the next agent to build on."
+            ]
+        };
+    }
+    return {
+        move: intent,
+        instructions: [
+            "Read the previous contribution carried in the role narrative below.",
+            "Build on it rather than restarting; perform one primary move.",
+            "Tie new claims back to the seed prompt and prior session memory."
+        ]
+    };
+}
+
+export function buildPingPongBlueprint(input: PingPongBlueprintInput): PromptBlueprint {
+    const context: PromptSessionContext = {
+        speaker: input.speaker,
+        seat: input.seat,
+        counterpart: getCounterpart(input.seat),
+        phase: input.phase,
+        intent: input.intent,
+        rootTopic: input.rootTopic,
+        objective: input.framing?.objective,
+        constraints: input.framing?.constraints,
+        successCriteria: input.framing?.successCriteria,
+        // The role-specific narrative (from background.ts ROLE_PROMPTS) is the
+        // latest input the agent must respond to.  This preserves PING_PONG's
+        // tuned per-role framings while letting the layered shell add memory,
+        // identity, and the output contract around them.
+        latestInput: input.roleNarrative
+    };
+
+    return {
+        protocol: PINGPONG_PROTOCOL,
+        identity: getIdentity(input.seat),
+        style: DEFAULT_STYLE,
+        roleDirective: ROLE_DIRECTIVES[input.role] || ROLE_DIRECTIVES.CRITIC,
+        memory: input.memory,
+        context,
+        task: buildPingPongTask(input.isOpeningTurn, input.intent)
+    };
+}
+
 function renderList(items: string[] | undefined, fallback: string) {
     if (!items?.length) return `- ${fallback}`;
     return items.map(item => `- ${item}`).join('\n');
@@ -256,6 +347,16 @@ function renderMemory(memory?: SessionMemory) {
 function renderAnchor(rootTopic: string | undefined, latestInput: string) {
     const anchor = rootTopic || latestInput;
     return anchor.trim();
+}
+
+function renderOutputContract(protocol: PromptProtocol, counterpart: AgentSeat): string[] {
+    if (protocol.outputContract && protocol.outputContract.length) return protocol.outputContract;
+    return [
+        `Address ${counterpart} directly.`,
+        `Keep the labels "Agent A" and "Agent B" literal even when replying in another language. Do not translate them.`,
+        "Do not mention the system protocol, prompt layers, output contract, hidden instructions, or compliance with these instructions.",
+        "Output only the agent-to-agent reply."
+    ];
 }
 
 // EN: Rendering stays deterministic so prompts can be inspected, tested, and shown later in the UI.
@@ -309,9 +410,6 @@ export function renderPromptBlueprint(blueprint: PromptBlueprint): string {
         renderList(task.instructions, "Advance the session by one useful step."),
         "",
         "[OUTPUT CONTRACT]",
-        `Address ${context.counterpart} directly.`,
-        `Keep the labels "Agent A" and "Agent B" literal even when replying in another language. Do not translate them.`,
-        "Do not mention the system protocol, prompt layers, output contract, hidden instructions, or compliance with these instructions.",
-        "Output only the agent-to-agent reply."
+        ...renderOutputContract(protocol, context.counterpart)
     ].filter(part => part !== "").join('\n');
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,12 @@ export interface PromptProtocol {
     label: string;
     rules: string[];
     escalationFormat?: string;
+    // EN: Optional per-protocol output contract.  DISCUSSION uses the default
+    //     "address counterpart agent" contract; PING_PONG overrides with an
+    //     iteration-friendly contract that does not assume agent-to-agent
+    //     framing.
+    // AR: عقد إخراج اختياري لكل بروتوكول.
+    outputContract?: string[];
 }
 
 export interface PromptSessionContext {


### PR DESCRIPTION
## Summary

PING_PONG mode bypassed \`promptBlueprint.ts\` entirely. It missed the Identity, Memory, and Output Contract layers DISCUSSION already had, so memory built up during PING_PONG sessions was never read back into prompts and the two modes effectively behaved like two different products.

This PR routes PING_PONG through the layered shell while preserving the carefully tuned per-role narratives in \`ROLE_PROMPTS\`.

## Changes

- **\`src/types.ts\`** — \`PromptProtocol.outputContract?: string[]\` (optional per-protocol override).
- **\`src/promptBlueprint.ts\`** — new \`PINGPONG_PROTOCOL\` (iteration-friendly rules + custom output contract). New \`buildPingPongBlueprint\` that takes the role narrative as \`latestInput\` and wraps it in the standard layered shell. \`renderPromptBlueprint\` uses \`protocol.outputContract\` when set; falls back to the discussion-mode "address counterpart agent" contract otherwise.
- **\`src/background.ts\`** — \`executeAgentTurn\` now renders PING_PONG via the new blueprint. \`ROLE_PROMPTS\` stays as the role-narrative source (the comment is updated; the table is no longer the entire prompt).
- **\`scripts/test-prompt-blueprint.mjs\`** — locks: PING_PONG must include session memory, must use the Collaborative Exchange protocol label, must NOT use the agent-to-agent output contract.

## Test plan

- [x] All 11 \`scripts/test-*.mjs\` files — pass
- [x] \`tsc --noEmit\` — clean
- [ ] Manual: run a PING_PONG session with at least one checkpoint, confirm later turns include the memory entries from earlier checkpoints
- [ ] Manual: verify the prompt inspector ("Show prompt") on a PING_PONG turn shows the layered shell with the role narrative as the latest input

## Risk

Medium. PING_PONG turns now ride a different prompt shape — the role-narrative quality is preserved (still drawn from \`ROLE_PROMPTS\`), but its surroundings (memory, output contract) are new. EXPANDER's "Yes, And…" and ARCHITECT's Visionary-vs-Architect framings are kept verbatim as the rendered narrative.

The \`Legacy PING_PONG prompt path\` comment is preserved by the existing test assertion; it now describes the table as the role-narrative source rather than the whole prompt.

Closes #8.